### PR TITLE
Process CSS after the whole site is written to disk

### DIFF
--- a/lib/jekyll-postcss-v2/hook.rb
+++ b/lib/jekyll-postcss-v2/hook.rb
@@ -38,8 +38,6 @@ end
 
 Jekyll::Hooks.register :site, :post_write do |site|
   site.pages.each do |page|
-    Jekyll.logger.debug "PostCSS v2:",
-                        "Processing #{page.url}"
     if %r!\.css$! =~ page.destination(site.dest)
       engine = PostCssV2::Engine.new(site.source, {
         script: site.config.dig("postcss", "script"),

--- a/lib/jekyll-postcss-v2/hook.rb
+++ b/lib/jekyll-postcss-v2/hook.rb
@@ -28,7 +28,7 @@ module PostCssV2
     end
 
     def process(page)
-      file_path = Pathname.new(page.site.dest + page.url)
+      file_path = Pathname.new(page.destination(page.site.dest))
       postcss_command = `#{@script} #{file_path} -r --config #{@config}`
       Jekyll.logger.info "PostCSS v2:",
                          "Rewrote #{page.url} #{postcss_command}"
@@ -36,12 +36,16 @@ module PostCssV2
   end
 end
 
-Jekyll::Hooks.register :pages, :post_write do |page|
-  if %r!\.css$! =~ page.url
-    engine = PostCssV2::Engine.new(page.site.source, {
-      script: page.site.config.dig('postcss', 'script'),
-      config: page.site.config.dig('postcss', 'config'),
-    })
-    engine.process(page)
+Jekyll::Hooks.register :site, :post_write do |site|
+  site.pages.each do |page|
+    Jekyll.logger.debug "PostCSS v2:",
+                        "Processing #{page.url}"
+    if %r!\.css$! =~ page.destination(site.dest)
+      engine = PostCssV2::Engine.new(site.source, {
+        script: site.config.dig("postcss", "script"),
+        config: site.config.dig("postcss", "config"),
+      })
+      engine.process(page)
+    end
   end
 end


### PR DESCRIPTION
This PR modifies the plugin to register the hook on the `:post_write` event of the `:site`, instead of the `:post_write` event of the `:pages`, to make sure that PostCSS processing is executed after the whole site is written to disk.

Previously, when using Tailwind CSS, for example, several classes would not be detected and added to the output CSS on first build because the source CSS file was processed in between the rest of the pages of site, so the subsequent pages would have missing styles, thus requiring two build steps to deploy to GitHub Pages. With these changes, CSS files marked with Front Matter are processed by this plugin after the whole site is written to disk, which ensures that all Tailwind CSS classes are detected, processed, and added to the output file. These fixes should fix similar problems with other PostCSS plugins but I haven't tested that.

I think this should close issue #2 

Thanks to @bglw for creating this plugin. Hope you have some spare time to review and approve this PR.